### PR TITLE
Feature/jdw.code.cleanup

### DIFF
--- a/streamlit_aggrid_redux/__init__.py
+++ b/streamlit_aggrid_redux/__init__.py
@@ -11,11 +11,12 @@ from streamlit.components.v1.components import MarshallComponentException
 
 # local imports
 from .code import JsCode
+from .types import DataElement
 from .errors import GridBuilderError, GridOptionsBuilderError
-from .grid_return import GridReturn, generate_response
-from .grid_builder import GridBuilder, DataElement
-from .grid_options_builder import GridOptionsBuilder
 from .version import version, __version__
+from .grid_return import GridReturn, generate_response
+from .grid_builder import GridBuilder
+from .grid_options_builder import GridOptionsBuilder
 
 # ensure these imports can be used in Python code importing this module
 __all__ = [

--- a/streamlit_aggrid_redux/__init__.py
+++ b/streamlit_aggrid_redux/__init__.py
@@ -59,7 +59,7 @@ def ag_grid(data: DataElement,
             update_on: List[str | Tuple[str, int]] = None,
             enable_quick_search: bool = False,
             excel_export_mode: str = "none",
-            **kwargs: Mapping) -> AgGridReturn:
+            **kwargs: Mapping) -> GridReturn:
     """Render the input data element using JS AgGrid.
 
     Parameters
@@ -186,11 +186,12 @@ def ag_grid(data: DataElement,
             errors,
             reload_data,
             columns_state,
-            theme
+            theme,
             custom_css,
             update_on,
             enable_quick_search,
             excel_export_mode
+            **kwargs
         )
     except (GridBuilderError, GridOptionsBuilderError, Exception) as err:
         # re-raise all errors as GridBuilder errors

--- a/streamlit_aggrid_redux/__init__.py
+++ b/streamlit_aggrid_redux/__init__.py
@@ -29,14 +29,15 @@ __all__ = [
 
 
 _RELEASE = config("AGGRID_RELEASE", default=True, cast=bool)
+_PORT = config("PORT", default=3001, cast=int)
 
 if not _RELEASE:
     warnings.warn("WARNING: streamlit-aggrid-redux is in development mode.")
-    _component_func = components.declare_component("agGrid", url="http://localhost:3001")
+    _component_func = components.declare_component("agGridRedux", url=f"http://localhost:{_PORT}")
 else:
     parent_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(parent_dir, "frontend", "build")
-    _component_func = components.declare_component("agGrid", path=build_dir)
+    _component_func = components.declare_component("agGridRedux", path=build_dir)
 
 
 # the main api
@@ -80,17 +81,17 @@ def ag_grid(data: DataElement,
     height: int, optional
         The height of the grid, in pixels. Default is
         None to let AgGrid/Streamlit decide height.
-        
+
     columns_auto_size_mode: str, optional
         A string flag to determine how AgGrid handles the width
         of columns. Options are "none", "fit" and "fit all".
         Default is "none" to not auto-size the columns.
-        
+
     return_mode: str, optional
         A string flag that determines how the data is returned
         from AgGrid. Options are "input", "filter" and "filter sort".
         Default is "input".
-        
+
     allow_unsafe_js: bool, optional
         A flag indicating whether we want to inject JS into the
         grid options (e.g., for formatting numbers or dates). Default
@@ -98,48 +99,48 @@ def ag_grid(data: DataElement,
 
         WARNING: There are no protections or checks of the code
         injected. Use at your own risk.
-        
+
     enable_enterprise_modules: bool, optional
         A flag indicating whether AgGrid Enterprise Modules
         should be loaded (True) or not (False). A license key
         is required to remove the Trial Version watermark; using
         the enterprise modules without the license should not be
         for production systems. Default is True.
-        
+
     license_key: str, optional
         The AgGrid Enterprise Module license key. Unused if
         `enable_enterprise_modules=False`. Default is None.
-        
+
     convert_to_original_types: bool, optional
         A flag indicating whether the modified data output should
         coerced back to the original types. Default is True.
-        
+
     errors: str, optional
         A string flag to passed to Pandas data converters. Options
         are "coerce", "ignore" or "raise". Default is "coerce" which
         makes invalid cells NaN/NaT.
-        
+
     reload_data: bool, optional
         A flag indicating whether AgGrid should reload data when
-        refreshing. Default is False.
-        
+        refreshing. Default is
+
     columns_state: List[Dict], optional
-        A set of dictionaries of how the data should be displayed 
+        A set of dictionaries of how the data should be displayed
         in AgGrid. Default is None.
-        
+
     theme: str, optional
         The theme to apply to the AgGrid display. Options are "streamlit",
         "alpine", "balham" and "excel".
-        
+
     custom_css: str, optional
         A stringified dictionary of custom CSS commands to pass to
         AgGrid. Default is None.
-        
+
     key: str, optional
         The streamlit key to pass to the component function for cases
         when data is displayed twice to avoid singleton errors. Default
         is None.
-        
+
     update_on: List[str | Tuple[str, int]], optiona
         A list of AgGrid update methods when a cell is modified. See
         https://www.ag-grid.com/javascript-data-grid/cell-editing/#editing-events
@@ -148,11 +149,11 @@ def ag_grid(data: DataElement,
         Useful update modes include, `cellValueChanged`, `selectionChanged`,
         `filterChanged`, `sortChanged`, `columnResized`, `columnMoved`,
         `columnPinned` and `columnVisible
-        
+
     enable_quick_search: bool, optional
         A flag indicating whether the quick search bar should appear
         at the top of the grid (True) or not (False). Default is False.
-        
+
     excel_export_mode: str, optional
         A string flag indicating how Excel export should be handled. Options
         are "none" to disable downloading the grid as a file, "manual" to
@@ -167,7 +168,7 @@ def ag_grid(data: DataElement,
     Returns
     -------
     AgGridReturn
-        An immutable class that returns the output from the AgGrid (e.g., 
+        An immutable class that returns the output from the AgGrid (e.g.,
         after modifications, filtering, sorting).
     """
     # first, use an internal class to massage the API inputs
@@ -192,7 +193,7 @@ def ag_grid(data: DataElement,
             excel_export_mode
         )
     except (GridBuilderError, GridOptionsBuilderError, Exception) as err:
-        # rereaise errors
+        # re-raise all errors as GridBuilder errors
         raise GridBuilderError(err)
 
     # if not in release mode, we hide a parameter "return_grid" that returns the grid
@@ -200,17 +201,16 @@ def ag_grid(data: DataElement,
         return grid
 
     # throw an error for now
-    raise NotImplementedError("Working on it")
-    
+    # raise NotImplementedError("Working on it")
+
     # now call the component
     try:
         component_value = _component_func(
             grid_options=grid.grid_options,
             row_data=grid.data,
             height=grid.height,
-            columns_auto_size_mode=grid.columns_auto_size_mode, 
-            return_mode=grid.return_mode, 
-            data_types=grid.data_types,
+            columns_auto_size_mode=grid.columns_auto_size_mode,
+            return_mode=grid.return_mode,
             allow_unsafe_js=grid.allow_unsafe_js,
             enable_enterprise_modules=grid.enable_enterprise_modules,
             license_key=grid.license_key,
@@ -219,19 +219,18 @@ def ag_grid(data: DataElement,
             theme=grid.theme,
             custom_css=grid.custom_css,
             update_on=grid.update_on,
-            manual_update=grid.manual_update,
             enable_quick_search=grid.enable_quick_search,
             excel_export_mode=grid.excel_export_mode,
             key=key
         )
     except MarshallComponentException as err:
-        # reraise this error but with JsCode note on it first, maybe.
+        # re-raise this error but with JsCode note on it first, maybe.
         args = list(err.args)
         if not grid.allow_unsafe_js:
             args[0] += ". If using custom JS Code, set allow_unsafe_js to True."
         # re-raise
         raise MarshallComponentException(*args)
-        
+
 
     # now generate the response
     return generate_response(component_value, data, grid.convert_to_original_types, grid.errors)

--- a/streamlit_aggrid_redux/frontend/package.json
+++ b/streamlit_aggrid_redux/frontend/package.json
@@ -3,79 +3,79 @@
     "version": "2023.10",
     "private": true,
     "dependencies": {
-	"@ag-grid-community/client-side-row-model": "^29.3.5",
-	"@ag-grid-community/core": "^29.3.5",
-	"@ag-grid-community/csv-export": "^29.3.5",
-	"@ag-grid-community/react": "^29.3.5",
-	"@ag-grid-community/styles": "^29.3.5",
-	"@ag-grid-enterprise/charts": "^29.3.5",
-	"@ag-grid-enterprise/clipboard": "^29.3.5",
-	"@ag-grid-enterprise/column-tool-panel": "^29.3.5",
-	"@ag-grid-enterprise/core": "^29.3.5",
-	"@ag-grid-enterprise/excel-export": "^29.3.5",
-	"@ag-grid-enterprise/filter-tool-panel": "^29.3.5",
-	"@ag-grid-enterprise/master-detail": "^29.3.5",
-	"@ag-grid-enterprise/menu": "^29.3.5",
-	"@ag-grid-enterprise/multi-filter": "^29.3.5",
-	"@ag-grid-enterprise/range-selection": "^29.3.5",
-	"@ag-grid-enterprise/rich-select": "^29.3.5",
-	"@ag-grid-enterprise/row-grouping": "^29.3.5",
-	"@ag-grid-enterprise/set-filter": "^29.3.5",
-	"@ag-grid-enterprise/side-bar": "^29.3.5",
-	"@ag-grid-enterprise/sparklines": "^29.3.5",
-	"@ag-grid-enterprise/status-bar": "^29.3.5",
-	"@fontsource/source-sans-pro": "^4.5.11",
-	"@astrouxds/ag-grid-theme": "^6.0.1",
-	"@types/jest": "^29.4.0",
-	"@types/lodash": "^4.14.191",
-	"@types/node": "^18.14.2",
-	"@types/react": "^18.0.28",
-	"@types/react-dom": "^18.0.11",
-	"apache-arrow": "^11.0.0",
-	"base64-arraybuffer": "^1.0.2",
-	"buffer": "^6.0.3",
-	"date-fns": "^2.29.3",
-	"date-fns-tz": "^2.0.0",
-	"lodash": "^4.17.21",
-	"moment": "^2.29.4",
-	"react": "^18.2.0",
-	"react-dom": "^18.2.0",
-	"react-scripts": "^5.0.1",
-	"sass": "^1.58.3",
-	"streamlit-component-lib": "^1.4.0",
-	"typescript": "^4.9.5"
+        "@ag-grid-community/client-side-row-model": "^29.3.5",
+        "@ag-grid-community/core": "^29.3.5",
+        "@ag-grid-community/csv-export": "^29.3.5",
+        "@ag-grid-community/react": "^29.3.5",
+        "@ag-grid-community/styles": "^29.3.5",
+        "@ag-grid-enterprise/charts": "^29.3.5",
+        "@ag-grid-enterprise/clipboard": "^29.3.5",
+        "@ag-grid-enterprise/column-tool-panel": "^29.3.5",
+        "@ag-grid-enterprise/core": "^29.3.5",
+        "@ag-grid-enterprise/excel-export": "^29.3.5",
+        "@ag-grid-enterprise/filter-tool-panel": "^29.3.5",
+        "@ag-grid-enterprise/master-detail": "^29.3.5",
+        "@ag-grid-enterprise/menu": "^29.3.5",
+        "@ag-grid-enterprise/multi-filter": "^29.3.5",
+        "@ag-grid-enterprise/range-selection": "^29.3.5",
+        "@ag-grid-enterprise/rich-select": "^29.3.5",
+        "@ag-grid-enterprise/row-grouping": "^29.3.5",
+        "@ag-grid-enterprise/set-filter": "^29.3.5",
+        "@ag-grid-enterprise/side-bar": "^29.3.5",
+        "@ag-grid-enterprise/sparklines": "^29.3.5",
+        "@ag-grid-enterprise/status-bar": "^29.3.5",
+        "@fontsource/source-sans-pro": "^4.5.11",
+        "@astrouxds/ag-grid-theme": "^6.0.1",
+        "@types/jest": "^29.4.0",
+        "@types/lodash": "^4.14.191",
+        "@types/node": "^18.14.2",
+        "@types/react": "^18.0.28",
+        "@types/react-dom": "^18.0.11",
+        "apache-arrow": "^11.0.0",
+        "base64-arraybuffer": "^1.0.2",
+        "buffer": "^6.0.3",
+        "date-fns": "^2.29.3",
+        "date-fns-tz": "^2.0.0",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.4",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-scripts": "^5.0.1",
+        "sass": "^1.58.3",
+        "streamlit-component-lib": "^1.4.0",
+        "typescript": "^4.9.5"
     },
     "scripts": {
-	"analyze": "source-map-explorer 'build/static/js/*.js'",
-	"start": "react-scripts start",
-	"build": "react-scripts build",
-	"test": "react-scripts test",
-	"eject": "react-scripts eject"
+        "analyze": "source-map-explorer 'build/static/js/*.js'",
+        "start": "react-scripts start",
+        "build": "react-scripts build",
+        "test": "react-scripts test",
+        "eject": "react-scripts eject"
     },
     "eslintConfig": {
-	"extends": "react-app"
+        "extends": "react-app"
     },
     "browserslist": {
-	"production": [
-	    ">0.2%",
-	    "not dead",
-	    "not op_mini all"
-	],
-	"development": [
-	    "last 1 chrome version",
-	    "last 1 firefox version",
-	    "last 1 safari version"
-	]
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
     },
     "homepage": ".",
     "devDependencies": {
-	"source-map-explorer": "^2.5.3",
-	"@babel/core": "7.2.0"
+        "source-map-explorer": "^2.5.3",
+        "@babel/core": "7.2.0"
     },
     "keywords": [
-	"javascript",
-	"starter"
-	"aggrid"
+        "javascript",
+        "starter",
+        "aggrid"
     ]
 }
     

--- a/streamlit_aggrid_redux/frontend/src/AgGrid.tsx
+++ b/streamlit_aggrid_redux/frontend/src/AgGrid.tsx
@@ -63,7 +63,7 @@ function getCSS(styles: CSSDict): string {
     return css.join("\n")
 }
 
-function addCustomCSS(customCss: CSSDict): void {
+function addCustomCss(customCss: CSSDict): void {
     var css = getCSS(customCss)
     var styleSheet = document.createElement("style")
     styleSheet.type = "text/css"
@@ -223,7 +223,7 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
         super(props)
         // console.log("Grid INIT called", props)
 
-        this.gridContainerReg = React.createRef()
+        this.gridContainerRef = React.createRef()
 
         ModuleRegistry.register(ClientSideRowModelModule)
         ModuleRegistry.register(CsvExportModule)
@@ -254,9 +254,9 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
             if ("license_key" in props.args) {
                 LicenseManager.setLicenseKey(props.args["license_key"])
             }
-	    else {
-	    	 console.log("Enterprise modules requested without license key; using trial version")
-	    }
+            else {
+                     console.log("Enterprise modules requested without license key; using trial version")
+            }
         }
 
         this.isGridAutoHeightOn = 
@@ -309,8 +309,8 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
 
     private clearSelectedRows() {
         if (this.api) {
-	    this.api.deselectAll()
-	}
+            this.api.deselectAll()
+        }
     }
 
     private resizeGridContainer() {
@@ -319,7 +319,7 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
             this.renderedGridHeightPrevious = renderedGridHeight
             Streamlit.setFrameHeight(renderedGridHeight)
 
-	    // Run fitColumns() only once when it first becomes visible with height > 0
+            // Run fitColumns() only once when it first becomes visible with height > 0
             // This should solve auto_size_mode issues with st.tabs
             if (this.notYetFitColumns) {
                 this.notYetFitColumns = false
@@ -343,7 +343,7 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
                 break
             
             default:
-	        // does nothing on purpose
+                // does nothing on purpose
                 break
         }
     }
@@ -449,9 +449,9 @@ class AgGrid<S = {}> extends React.Component<ComponentProps, S> {
         }
 
         // maybe clear the selected rows
-	if (this.gridOptions.clearCheckboxOnReload) {
-	    this.clearSelectedRows()
-	}
+        if (this.gridOptions.clearCheckboxOnReload) {
+            this.clearSelectedRows()
+        }
     }
 
     private onGridReady(event: any) {

--- a/streamlit_aggrid_redux/frontend/tsconfig.json
+++ b/streamlit_aggrid_redux/frontend/tsconfig.json
@@ -1,26 +1,26 @@
 {
     "compilerOptions": {
-	"target": "es5",
-	"lib": [
-	    "dom",
-	    "dom.iterable",
-	    "esnext"
-	],
-	"allowJs": true,
-	"skipLibCheck": true,
-	"esModuleInterop": true,
-	"allowSyntheticDefaultImports": true,
-	"strict": true,
-	"forceConsistentCasingInFileNames": true,
-	"module": "esnext",
-	"moduleResolution": "node",
-	"resolveJsonModule": true,
-	"isolatedModules": true,
-	"noEmit": true,
-	"jsx": "react-jsx",
-	"noFallthroughCasesInSwitch": true
+        "target": "es5",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "esnext"
+        ],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx",
+        "noFallthroughCasesInSwitch": true
     },
     "include": [
-	"src"
+        "src"
     ]
 }

--- a/streamlit_aggrid_redux/grid_builder.py
+++ b/streamlit_aggrid_redux/grid_builder.py
@@ -4,13 +4,15 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from typing import Any, List, Mapping, Union, Any, Dict, Tuple
+from typing import List, Mapping, Union, Dict, Tuple, Literal
+from streamlit.type_util import convert_anything_to_df
 
 # local import
+from .code import JsCode
 from .errors import GridBuilderError, GridOptionsBuilderError
 from .grid_options_builder import GridOptionsBuilder, walk_grid_options
 
-DataElement = Union[pd.DataFrame, pa.Table, np.ndarray, str]
+DataElement = Union[pd.DataFrame, pa.Table, np.ndarray, dict, str]
 
 
 ######################################################################
@@ -20,33 +22,16 @@ def _make_error_msg(field: str, input: str, options: List[str]):
     """ Helper function to make a cleaner error message. """
     opts = ', '.join(map(lambda x: f"'{x}'", options))
     return f"Input {field} '{input}' is invalid. Options are {opts}."
-
-
-class NumpyArrayEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, numpy.ndarray):
-            return obj.tolist()
-        return json.JSONEncoder.default(self, obj)
         
         
 def _serialize_data(data: DataElemet) -> Dict:
     """ Convert the input data element into a JSON string. """
-    if isinstance(data, pd.DataFrame):
-        return data.to_dict(orient="records")
-    elif isinstnace(data, pa.Table):
-        # There ought to be a better way for serializing pyarrow tables
-        return data.to_pydict()
-    elif isinstance(data, np.ndarray):
-        # use json decoder
-        return json.dumps(data, cls=NumpyArrayEncoder)
-    elif isinstance(data, str):
-        # presume it's already JSON
-        try:
-            return json.loads(data)
-        except json.decoder.JSONDecodeError:
-            raise GridBuilderError("Cannot convert input data from string to JSON dictionary")
-    else:
+    try:
+        frame = convert_anything_to_df(data, ensure_copy=True, allow_styler=False)
+    except ValueError:
+        # reraise error
         raise GridBuilderError(f"Cannot serialize data of type '{type(data)}'")
+    return frame.to_dict()
 
 
 def _process_auto_size_mode(mode: str) -> int:
@@ -105,28 +90,19 @@ def _process_excel_export_mode(mode: str) -> str:
         )
 
 
-def _process_data_types(convert: bool, data: DataElement) -> List:
-    """ If conversion is requested, return the list of data element types. """
-    if not convert:
-        return []
-    if isinstance(data, pd.DataFrame):
-        return dict(zip(data.columns, (t.kind for t in data.dtypes)))
-    elif isinstance(data, pa.Table):
-        # FIXME: ensure this works. Could just use above
-        schema = data.schema
-        return dict(zip(data.column_names, (schema.field(c).type for c in data.column_names)))
-    elif isinstance(data, np.ndarray):
-        # FIXME: figure this one out
-        return []
-    else:
-        raise GridBuilderError(f"Cannot get data types of input data with type '{type(data)}'")
+def _process_conversion_errors(convert: bool, errors: str) -> str:
+    if convert and errors not in ("raise", "coerce", "ignore"):
+        raise GridBuilderError(
+            f"Error handling '{errors}' is invalid, should be 'raise', 'coerce' or 'ignore'"
+        )
+    return errors
         
 
 ######################################################################
 # Builder Class
 ######################################################################
 class AgGridBuilder:
-    data: str = "{}"
+    data: Dict = dict()
     grid_options: Dict = None
     height: int = None
     columns_auto_size_mode: int = 0
@@ -135,7 +111,7 @@ class AgGridBuilder:
     enable_enterprise_modules: bool = True
     license_key: str = None
     convert_to_original_types: bool = True
-    errors: str = "coerce"
+    errors: Literal["raise", "ignore", "coerce"] = "coerce"
     dtypes: Union[List[str], Dict[str, List[str]]] = None
     reload_data: bool = False
     columns_state: List[Dict] = None
@@ -146,8 +122,8 @@ class AgGridBuilder:
     excel_export_mode: str = "none"
 
     def __new__(cls,
-                data: Union[pd.DataFrame, pa.Table, np.ndarray, str],
-                grid_options: Dict = None,
+                data: DataElement,
+                grid_options: Union[Dict, GridOptionsBuilder] = None,
                 height: int = None,
                 columns_auto_size_mode: str = "none",
                 return_mode: str = "input",
@@ -160,7 +136,6 @@ class AgGridBuilder:
                 columns_state: List[Dict] = None,
                 theme: str = "streamlit",
                 custom_css: str = None,
-                use_legacy_selected_rows: bool = False,
                 update_on: List[str | Tuple[str, int]] = None,
                 enable_quick_search: bool = False,
                 excel_export_mode: str = "none",
@@ -172,17 +147,16 @@ class AgGridBuilder:
         obj.data = _serialize_data(data)
         obj.columns_auto_size_mode = _process_auto_size_mode(columns_auto_size_mode.lower())
         obj.return_mode = _process_return_mode(return_mode.lower())
-        obj.convert_to_original_types = convert_to_original_types
         obj.errors = _process_conversion_errors(convert_to_original_types, errors.lower())
         obj.theme = _process_theme(theme.lower())
         obj.excel_export_mode = _process_excel_export_mode(excel_export_mode.lower())
-        obj.dtypes = _process_data_types(convert_to_original_types, data)
 
         # remaining items do not need cleaning
         obj.height = height
         obj.allow_unsafe_js = allow_unsafe_js
         obj.enable_enterprise_modules = enable_enterprise_modules
         obj.license_key = license_key
+        obj.convert_to_original_types = convert_to_original_types
         obj.reload_data = reload_data
         obj.columns_state = column_state
         obj.custom_css = custom_css
@@ -197,6 +171,7 @@ class AgGridBuilder:
 
         # now update with the passed kwargs
         obj.grid_options.update(**kwargs)
+        walk_grid_options(obj.grid_options, lambda v: v.code if isinstance(v, JsCode) else v)
         
         return obj.process_deprecated(**kwargs)
 

--- a/streamlit_aggrid_redux/grid_builder.py
+++ b/streamlit_aggrid_redux/grid_builder.py
@@ -5,15 +5,14 @@ import pandas as pd
 import pyarrow as pa
 
 from typing import List, Mapping, Union, Dict, Tuple, Literal
-from streamlit.type_util import convert_anything_to_df
 from streamlit.errors import StreamlitAPIException
+from streamlit.type_util import convert_anything_to_df
 
 # local import
 from .code import JsCode
-from .errors import GridBuilderError, GridOptionsBuilderError
+from .types import DataElement
+from .errors import GridBuilderError
 from .grid_options_builder import GridOptionsBuilder, walk_grid_options
-
-DataElement = Union[pd.DataFrame, pa.Table, np.ndarray, dict, str]
 
 
 ######################################################################

--- a/streamlit_aggrid_redux/grid_options_builder.py
+++ b/streamlit_aggrid_redux/grid_options_builder.py
@@ -8,10 +8,8 @@ from typing import Dict, Union, Mapping, List, Callable
 from streamlit.type_util import convert_anything_to_df
 
 # local import
+from .types import DataElement
 from .errors import GridOptionsBuilderError
-
-
-DataElement = Union[np.ndarray, pd.DataFrame, pa.Table, dict, str]
 
 
 def _pandas_types(d: str) -> List[str]:

--- a/streamlit_aggrid_redux/grid_options_builder.py
+++ b/streamlit_aggrid_redux/grid_options_builder.py
@@ -58,7 +58,7 @@ class GridOptionsBuilder:
             self.default_options.update(kwargs)
 
     @staticmethod
-    def from_data(data: DataElement) -> GridOptionsBuilder:
+    def from_data(data: DataElement) -> 'GridOptionsBuilder':
         """For people who like defaults and simple things,
         this API allows users to pass in the data and
         let this package fill the columns and set the
@@ -82,12 +82,12 @@ class GridOptionsBuilder:
         frame = convert_anything_to_df(data, ensure_copy=True, allow_styler=False)
         for name, type in zip(frame.columns, frame.dtypes):
             if "." in name:
-                obj.grid_options["suppressFieldDotNotation"] = True
+                opt.grid_options["suppressFieldDotNotation"] = True
             opt.add_column(name, name **{type: _pandas_types(type)})
        
         return opt
 
-    def add_column(self, field: str, header: str = None, **options: Mapping = None) -> 'GridOptionsBuilder':
+    def add_column(self, field: str, header: str = None, **options: Mapping) -> 'GridOptionsBuilder':
         """Add a new column to the configuration. Will throw
         and error if the field already exists in the options;
         to update, use `update_column()` method.
@@ -127,7 +127,7 @@ class GridOptionsBuilder:
         self.grid_options["columnDefs"][field] = defs
         return self
 
-    def update_column(self, field: str, header: str = None, **options: Mapping = None) -> 'GridOptionsBuilder':
+    def update_column(self, field: str, header: str = None, **options: Mapping) -> 'GridOptionsBuilder':
         """Update an existing column to the configuration. Will throw
         and error if the field does not exist in the options;
         to add, use `add_column()` method.
@@ -151,7 +151,7 @@ class GridOptionsBuilder:
         GridOptionsBuilder
             The updated object.
         """
-        if field in not self.grid_options["columnDefs"]:
+        if field not in self.grid_options["columnDefs"]:
             raise GridOptionsBuilderError(
                 f"Field '{field}' does not exist in options; use `add_column` instead."
             )
@@ -402,7 +402,7 @@ class GridOptionsBuilder:
         """
         if not isinstance(self.grid_options["columnDefs"], list):
             self.grid_options["columnDefs"] = list(self.grid_options["columnDefs"].values())
-        rerun self.grid_options
+        return self.grid_options
 
     def __str__(self):
         """ Print the grid options. """

--- a/streamlit_aggrid_redux/grid_return.py
+++ b/streamlit_aggrid_redux/grid_return.py
@@ -24,7 +24,7 @@ class GridReturn(tuple):
         return obj
 
 
-def _cast_to_time_delta(x: pd.Series) -> Optional[pd.Timedelta, pd.Series]:
+def _cast_to_time_delta(x: pd.Series) -> Union[pd.Timedelta, pd.Series]:
     """ Try coercing the series to a Timedelta object. """
     try:
         return pd.Timedelta(x)
@@ -95,7 +95,7 @@ def generate_response(data: Union[pd.DataFrame, pa.Table, np.ndarray, str],
         # no data type coercion possible?
         frame = frame.to_json()
         
-    return AgGridReturn(
+    return GridReturn(
         frame,
         component_value["selectedItems"],
         component_value["colState"]

--- a/streamlit_aggrid_redux/types.py
+++ b/streamlit_aggrid_redux/types.py
@@ -1,0 +1,7 @@
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+from typing import Union
+
+DataElement = Union[np.ndarray, pd.DataFrame, pa.Table, dict, str]

--- a/streamlit_aggrid_redux/version.py
+++ b/streamlit_aggrid_redux/version.py
@@ -18,4 +18,4 @@ def version() -> str:
 
 def version_tuple() -> tuple:
     """ The package version number as a tuple. """
-    return __version__tuple
+    return __version_tuple__


### PR DESCRIPTION
Running code through VSCode linting (previously all development through Emacs)

* Moved DataElement definition to types file
* Cleaned whitespace (removing ws-only & trailing, change tabs to spaces)
* Added missing functions
* Corrected class names (e.g., left as `AgGridReturn` when referred to elsewhere as `GridReturn`)
